### PR TITLE
Improve composer.json and fix DB pass in WP install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A code library for WP Syntex projects, containing:
 
 The test suite is installed in **this package**'s `tmp` folder.
 
-To tell the installation script how to connect to your database, you can create a `DB-CONFIG` file at the root of your project and formatted like follow (the file is not versioned with git of course).
+To tell the installation script how to connect to your database, you can create a `DB-CONFIG` file at the root of your project and formatted like follow (the file is not versioned with git of course).  
 Each line is optional, the default values are:
 
 ```txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A code library for WP Syntex projects, containing:
 
 The test suite is installed in **this package**'s `tmp` folder.
 
-To tell the installation script how to connect to your database, you can create a `DB-CONFIG` file at the root of your project and formatted like follow (the file is not versioned with git of course).  
+To tell the installation script how to connect to your database, you can create a `DB-CONFIG` file at the root of your project and formatted like follow (the file is not versioned with git of course).
 Each line is optional, the default values are:
 
 ```txt
@@ -58,7 +58,7 @@ license {PLUGIN-SLUG}:{YOUR-LICENSE}
 site {PLUGIN-SLUG}:{YOUR-SITE}
 ```
 
-Depending on EDD config, the `site` line may not be required.  
+Depending on EDD config, the `site` line may not be required.
 Also, if your plugin from EDD doesn't require a license key, do the following:
 
 ```txt
@@ -249,35 +249,3 @@ protected static $mockCommonWpFunctionsInSetUp = true;
 ```
 
 Like for integration tests, some helpers are available in your tests, from the `TestCaseTrait` trait.
-
-### PHPStan
-
-Since this project contains some PHPStan-related packages, you can use a few things directly:
-
-- `php-stubs/woocommerce-stubs`,
-- `wpsyntex/polylang-phpstan`,
-- `wpsyntex/polylang-stubs`.
-
-Example for your `phpstan.neon.dist` file:
-
-```neon
-includes:
-    - phar://phpstan.phar/conf/bleedingEdge.neon
-    - vendor/wpsyntex/polylang-phpstan/extension.neon
-parameters:
-    level: max
-    paths:
-        - %currentWorkingDirectory%/src
-        - %currentWorkingDirectory%/Tests
-        - %currentWorkingDirectory%/polylang-foobar.php
-    excludes_analyse:
-        - src/Dependencies/*
-    bootstrapFiles:
-        - vendor/wpsyntex/wp-phpunit/tmp/wordpress-tests-lib/includes/testcase.php
-        - vendor/wpsyntex/polylang-stubs/polylang-stubs.php
-    scanDirectories:
-        - vendor/wpsyntex/wp-phpunit/tmp/wordpress-tests-lib/includes
-        - vendor/wpsyntex/wp-phpunit/UnitTests
-    ignoreErrors:
-        - '#^Constant WPSYNTEX_PROJECT_PATH not found\.$#'
-```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ license {PLUGIN-SLUG}:{YOUR-LICENSE}
 site {PLUGIN-SLUG}:{YOUR-SITE}
 ```
 
-Depending on EDD config, the `site` line may not be required.
+Depending on EDD config, the `site` line may not be required.  
 Also, if your plugin from EDD doesn't require a license key, do the following:
 
 ```txt

--- a/bin/install-wp-suite.sh
+++ b/bin/install-wp-suite.sh
@@ -52,10 +52,6 @@ installWpSuite() {
 		local DB_PASS=''
 	fi
 
-	if [[ '' == $DB_PASS ]]; then
-		DB_PASS="''"
-	fi
-
 	if [[ $1 ]]; then
 		WP_VERSION=$1
 	fi
@@ -71,7 +67,7 @@ installWpSuite() {
   - DB pass: ${INFO_C}${DB_PASS}${NO_C}
   - WP version: ${INFO_C}${WP_VERSION}${NO_C}
   - Skip DB creation: ${INFO_C}${SKIP_DB_CREATION}${NO_C}"
-	. "$PARENT_DIR/install-wp-tests.sh" $DB_NAME $DB_USER $DB_PASS $DB_HOST $WP_VERSION $SKIP_DB_CREATION
+	. "$PARENT_DIR/install-wp-tests.sh" "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION" "$SKIP_DB_CREATION"
 }
 
 # Returns the value of the given config name.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"brain/monkey": "^2.0",
 		"cheprasov/php-cli-args": "^3.0",
 		"php-stubs/woocommerce-stubs": "*",
-		"phpunit/phpunit": "^5.7",
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.5",
 		"symfony/console": "^3.4 || ^4.4",
 		"wpsyntex/polylang-phpstan": "dev-master",
 		"wpsyntex/polylang-stubs": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"brain/monkey": "^2.0",
 		"cheprasov/php-cli-args": "^3.0",
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.5",
-		"symfony/console": "^3.4 || ^4.4",
+		"symfony/console": "^3.4 || ^4.4"
 	},
 	"require-dev": {
 		"wpsyntex/polylang-phpstan": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
 		"php": ">=5.6",
 		"brain/monkey": "^2.0",
 		"cheprasov/php-cli-args": "^3.0",
-		"php-stubs/woocommerce-stubs": "*",
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.5",
 		"symfony/console": "^3.4 || ^4.4",
-		"wpsyntex/polylang-phpstan": "dev-master",
-		"wpsyntex/polylang-stubs": "dev-master"
 	},
 	"require-dev": {
+		"wpsyntex/polylang-phpstan": "dev-master",
+		"wpsyntex/polylang-stubs": "dev-master",
+		"php-stubs/woocommerce-stubs": "*",
 		"wpsyntex/polylang-cs": "dev-main"
 	},
 	"autoload": {


### PR DESCRIPTION
This PR includes various fixes:
* Allow to use any stable version of PHPUnit from 5.7 to 9.5. This will allow dependent projects to select the right version depending on the PHP version tested.
* Move PHPStan and stubds to `require-dev` section. This allows dependent projects to use PHP 5.6, as PHPStan requires PHP 7.1.
* Fixes an issue with the DB_PASS variable in `install-wp-suite.sh`. When having an empty password, the previous version resulted in `''''` written in `wp-test-config.php`. 