### PR TITLE
Adapt for first use

### DIFF
--- a/Fixtures/DummyTestCase.php
+++ b/Fixtures/DummyTestCase.php
@@ -9,26 +9,12 @@
 namespace WP_Syntex\Polylang_Phpunit\Fixtures;
 
 use WP_Syntex\Polylang_Phpunit\Integration\TestCaseTrait;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use WP_UnitTestCase;
 
 /**
  * Dummy test case so PHPStan can analyze TestCaseTrait.
  */
-class DummyTestCase extends TestCase {
+class DummyTestCase extends WP_UnitTestCase {
 
 	use TestCaseTrait;
-
-	/**
-	 * Sets up the fixture, for example, open a network connection.
-	 *
-	 * @return void
-	 */
-	protected function setUp(): void {
-		// Must be set before calling `parent::set_up()`.
-		$this->activePlugins = [
-			'wp-all-import-pro/wp-all-import-pro.php',
-		];
-
-		parent::setUp();
-	}
 }

--- a/Fixtures/DummyTestCase.php
+++ b/Fixtures/DummyTestCase.php
@@ -9,21 +9,26 @@
 namespace WP_Syntex\Polylang_Phpunit\Fixtures;
 
 use WP_Syntex\Polylang_Phpunit\Integration\TestCaseTrait;
-use WP_UnitTestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Dummy test case so PHPStan can analyze TestCaseTrait.
  */
-class DummyTestCase extends WP_UnitTestCase {
-
-	/**
-	 * List of active plugins.
-	 *
-	 * @var array<string>
-	 */
-	protected $activePlugins = [
-		'wp-all-import-pro/wp-all-import-pro.php',
-	];
+class DummyTestCase extends TestCase {
 
 	use TestCaseTrait;
+
+	/**
+	 * Sets up the fixture, for example, open a network connection.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		// Must be set before calling `parent::set_up()`.
+		$this->activePlugins = [
+			'wp-all-import-pro/wp-all-import-pro.php',
+		];
+
+		parent::setUp();
+	}
 }

--- a/Fixtures/DummyTestCase.php
+++ b/Fixtures/DummyTestCase.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Dummy test case so PHPStan can analyze TestCaseTrait.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Fixtures
  */

--- a/Fixtures/DummyTestCase.php
+++ b/Fixtures/DummyTestCase.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Dummy test case so PHPStan can analyze TestCaseTrait.
+ * php version 5.6
+ *
+ * @package WP_Syntex\Polylang_Phpunit\Fixtures
+ */
+
+namespace WP_Syntex\Polylang_Phpunit\Fixtures;
+
+use WP_Syntex\Polylang_Phpunit\Integration\TestCaseTrait;
+use WP_UnitTestCase;
+
+/**
+ * Dummy test case so PHPStan can analyze TestCaseTrait.
+ */
+class DummyTestCase extends WP_UnitTestCase {
+
+	/**
+	 * List of active plugins.
+	 *
+	 * @var array<string>
+	 */
+	protected $activePlugins = [
+		'wp-all-import-pro/wp-all-import-pro.php',
+	];
+
+	use TestCaseTrait;
+}

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Example for your `bootstrap.php` file:
 <?php
 /**
  * Bootstraps the Polylang Foobar integration tests
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Foobar\Tests\Integration
  */
@@ -128,7 +128,7 @@ require dirname( dirname( __DIR__ ) ) . '/vendor/wpsyntex/wp-phpunit/UnitTests/I
 
 bootstrapSuite(
     dirname( __DIR__ ), // Path to the directory containing all tests.
-    '5.6.0', // The PHP version required to run this test suite.
+    '7.0.0', // The PHP version required to run this test suite.
     [
         'plugins' => [
             'polylang-pro/polylang.php'                            => true,
@@ -161,7 +161,7 @@ Hint: if you need to create your own methods `set_up()`, `wpSetUpBeforeClass`, e
 <?php
 /**
  * Test Case for all of the integration tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Foobar\Tests\Integration
  */
@@ -196,7 +196,7 @@ If you need to list some plugins among the "active ones" (`get_option( 'active_p
 <?php
 /**
  * Test Case for all of the integration tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Foobar\Tests\Integration
  */
@@ -236,7 +236,7 @@ Example for your `bootstrap.php` file:
 <?php
 /**
  * Bootstraps the Polylang Foobar Unit Tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Foobar\Tests\Unit
  */
@@ -247,7 +247,7 @@ use function WP_Syntex\Polylang_Phpunit\Unit\bootstrapSuite;
 
 require dirname( dirname( __DIR__ ) ) . '/vendor/wpsyntex/wp-phpunit/UnitTests/Unit/bootstrap.php';
 
-bootstrapSuite( dirname( __DIR__ ), '5.6.0' );
+bootstrapSuite( dirname( __DIR__ ), '7.0.0' );
 ```
 
 #### Extend the abstract class in your unit tests
@@ -262,7 +262,7 @@ In your tests you can mock [WordPress' most common functions](https://github.com
 <?php
 /**
  * Tests for `WP_Syntex\Polylang_Foobar\barbaz()`.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Foobar\Tests\Unit
  */

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Then you can create composer scripts like these ones for example:
         "install-tests-with-db": "Installs both the WordPress tests suite (with database creation) and the dependencies needed for integration tests, without creating the database.",
         "build": "Builds the project.",
         "build-update": "Builds the project (runs `composer update` instead of `composer install`).",
-        "dist": "Make the zip file to distibute the project release."
+        "dist": "Makes the zip file to distibute the project release."
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A code library for WP Syntex projects, containing:
 
 ### Install the test suite
 
-The test suite is installed in **this package**'s `tmp` folder.
+The test suite is installed in  **your project**'s `tmp` folder.
 
 To tell the installation script how to connect to your database, you can create a `DB-CONFIG` file at the root of your project and formatted like follow (the file is not versioned with git of course).  
 Each line is optional, the default values are:

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -99,18 +99,17 @@ class Bootstrap {
 			$_SERVER['SERVER_NAME'] = 'localhost';
 		}
 
-		if ( 'Unit' === $this->suite ) {
-			/**
-			 * Unit tests:
-			 * Load Patchwork before everything else in order to allow us to redefine WordPress, 3rd party, and plugin's
-			 * functions.
-			 */
-			$patchworkPath = __DIR__ . '/../vendor/antecedent/patchwork/Patchwork.php';
+		/**
+		 * Load Patchwork before everything else in order to allow us to redefine WordPress, 3rd party, and plugin's
+		 * functions.
+		 */
+		$patchworkPath = __DIR__ . '/../vendor/antecedent/patchwork/Patchwork.php';
 
-			if ( file_exists( $patchworkPath ) ) {
-				require_once $patchworkPath;
-			}
-		} else {
+		if ( file_exists( $patchworkPath ) ) {
+			require_once $patchworkPath;
+		}
+
+		if ( 'Integration' === $this->suite ) {
 			/**
 			 * Integration tests:
 			 * Give access to tests_add_filter() function.

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -103,7 +103,7 @@ class Bootstrap {
 		 * Load Patchwork before everything else in order to allow us to redefine WordPress, 3rd party, and plugin's
 		 * functions.
 		 */
-		$patchworkPath = __DIR__ . '/../vendor/antecedent/patchwork/Patchwork.php';
+		$patchworkPath = dirname( __DIR__ ) . '/vendor/antecedent/patchwork/Patchwork.php';
 
 		if ( file_exists( $patchworkPath ) ) {
 			require_once $patchworkPath;

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -23,6 +23,13 @@ class Bootstrap {
 	private $suite;
 
 	/**
+	 * Path to the directory of the project.
+	 *
+	 * @var string
+	 */
+	private $rootDir;
+
+	/**
 	 * Path to the directory containing all tests.
 	 *
 	 * @var string
@@ -64,13 +71,15 @@ class Bootstrap {
 	 *
 	 * @param  string                     $testSuite  Directory name of the test suite. Possible values are
 	 *                                                'Integration' and 'Unit'. Default is 'Unit'.
-	 * @param  string                     $testsDir   Path to the directory containing all tests.
+	 * @param  string                     $rootDir    Path to the directory of the project.
+	 * @param  string                     $testsDir   Path to the directory containing the tests, fixtures, etc.
 	 * @param  string                     $phpVersion The PHP version required to run this test suite.
 	 * @param  array<array<mixed>|string> $cliArgs    Addition config for CliArgs.
 	 * @return void
 	 */
-	public function __construct( $testSuite, $testsDir, $phpVersion, array $cliArgs = [] ) {
+	public function __construct( $testSuite, $rootDir, $testsDir, $phpVersion, array $cliArgs = [] ) {
 		$this->suite      = 'Integration' === $testSuite ? $testSuite : 'Unit';
+		$this->rootDir    = rtrim( $rootDir, '/\\' );
 		$this->testsDir   = rtrim( $testsDir, '/\\' );
 		$this->phpVersion = $phpVersion;
 		$this->cliArgs    = $cliArgs;
@@ -253,7 +262,7 @@ class Bootstrap {
 	 * @return void
 	 */
 	private function initConstants() {
-		define( 'WPSYNTEX_PROJECT_PATH', dirname( $this->testsDir ) . DIRECTORY_SEPARATOR );
+		define( 'WPSYNTEX_PROJECT_PATH', $this->rootDir . DIRECTORY_SEPARATOR );
 		define( 'WPSYNTEX_TESTS_PATH', $this->testsDir . DIRECTORY_SEPARATOR . $this->suite . DIRECTORY_SEPARATOR );
 		define( 'WPSYNTEX_FIXTURES_PATH', $this->testsDir . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR );
 		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', WPSYNTEX_PROJECT_PATH . 'vendor/yoast/phpunit-polyfills/' );

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -265,6 +265,7 @@ class Bootstrap {
 		define( 'WPSYNTEX_PROJECT_PATH', $this->rootDir . DIRECTORY_SEPARATOR );
 		define( 'WPSYNTEX_TESTS_PATH', $this->testsDir . DIRECTORY_SEPARATOR . $this->suite . DIRECTORY_SEPARATOR );
 		define( 'WPSYNTEX_FIXTURES_PATH', $this->testsDir . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR );
+		define( 'WPSYNTEX_TESTSUITE_PATH', $this->getWpTestsDir() . DIRECTORY_SEPARATOR );
 		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', WPSYNTEX_PROJECT_PATH . 'vendor/yoast/phpunit-polyfills/' );
 
 		if ( 'Unit' === $this->suite && ! defined( 'ABSPATH' ) ) {

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class to use to bootstrap tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit
  */

--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -158,7 +158,7 @@ class Bootstrap {
 	 * @return bool
 	 */
 	public function isGroup( $group ) {
-		$groups = $this->getCliArgsInst()->getArg( 'group' );
+		$groups = (array) $this->getCliArgsInst()->getArg( 'group' );
 		return in_array( $group, $groups, true );
 	}
 

--- a/UnitTests/Integration/TestCaseTrait.php
+++ b/UnitTests/Integration/TestCaseTrait.php
@@ -15,7 +15,6 @@ use PLL_Admin_Model;
 use PLL_Install;
 use WP_Syntex\Polylang_Phpunit\TestCaseTrait as GlobalTestCaseTrait;
 use WP_UnitTest_Factory;
-use WP_UnitTestCase;
 
 /**
  * Test Case for all of the integration tests.
@@ -62,11 +61,7 @@ trait TestCaseTrait {
 	public function set_up() {
 		parent::set_up();
 
-		/**
-		 * `$this->activePlugins` must be an array of paths to plugin files, relative to the plugins directory.
-		 *
-		 * @var array<string>
-		 */
+		// `$this->activePlugins` must be an array of paths to plugin files, relative to the plugins directory.
 		if ( ! empty( $this->activePlugins ) ) {
 			add_filter( 'pre_option_active_plugins', [ $this, 'filterActivePlugins' ] );
 		}
@@ -150,18 +145,23 @@ trait TestCaseTrait {
 		}
 
 		// Delete the default categories first.
-		$terms = wp_get_object_terms( get_option( 'default_category' ), 'term_translations' );
+		$default_category = get_option( 'default_category' );
+		$default_category = is_numeric( $default_category ) ? (int) $default_category : 0;
 
-		if ( ! is_wp_error( $terms ) ) {
-			foreach ( $terms as $term ) {
-				wp_delete_term( $term->term_id, 'term_translations' ); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+		if ( $default_category ) {
+			$terms = wp_get_object_terms( $default_category, 'term_translations' );
+
+			if ( ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $term ) {
+					wp_delete_term( $term->term_id, 'term_translations' ); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+				}
 			}
-		}
 
-		$terms = self::$model->term->get_translations( get_option( 'default_category' ) );
+			$terms = self::$model->term->get_translations( $default_category );
 
-		foreach ( $terms as $termId ) {
-			wp_delete_term( $termId, 'category' );
+			foreach ( $terms as $termId ) {
+				wp_delete_term( $termId, 'category' );
+			}
 		}
 
 		foreach ( $languages as $lang ) {

--- a/UnitTests/Integration/TestCaseTrait.php
+++ b/UnitTests/Integration/TestCaseTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Test Case for all of the integration tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Integration
  */

--- a/UnitTests/Integration/TestCaseTrait.php
+++ b/UnitTests/Integration/TestCaseTrait.php
@@ -20,6 +20,7 @@ use WP_UnitTest_Factory;
  * Test Case for all of the integration tests.
  */
 trait TestCaseTrait {
+
 	use GlobalTestCaseTrait;
 
 	/**
@@ -28,6 +29,14 @@ trait TestCaseTrait {
 	 * @var PLL_Admin_Model
 	 */
 	protected static $model;
+
+	/**
+	 * List of active plugins.
+	 * Array of paths to plugin files, relative to the plugins directory.
+	 *
+	 * @var array<non-falsy-string>
+	 */
+	protected $activePlugins = [];
 
 	/**
 	 * Initialization before all tests run.
@@ -61,7 +70,6 @@ trait TestCaseTrait {
 	public function set_up() {
 		parent::set_up();
 
-		// `$this->activePlugins` must be an array of paths to plugin files, relative to the plugins directory.
 		if ( ! empty( $this->activePlugins ) ) {
 			add_filter( 'pre_option_active_plugins', [ $this, 'filterActivePlugins' ] );
 		}

--- a/UnitTests/Integration/WooCommerce/Bootstrap.php
+++ b/UnitTests/Integration/WooCommerce/Bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Modified version of WooCommerce test bootstrap.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Integration\WooCommerce
  */

--- a/UnitTests/Integration/WooCommerce/Bootstrap.php
+++ b/UnitTests/Integration/WooCommerce/Bootstrap.php
@@ -8,7 +8,6 @@
 
 namespace WP_Syntex\Polylang_Phpunit\Integration\WooCommerce;
 
-use Automattic\WooCommerce\Admin\Install as WooInstall;
 use WC_Install;
 
 /**
@@ -35,9 +34,15 @@ class Bootstrap {
 
 		WC_Install::install();
 
-		// Initialize the WC Admin package.
-		WooInstall::create_tables();
-		WooInstall::create_events();
+		if ( class_exists( '\Automattic\WooCommerce\Internal\Admin\Install' ) ) {
+			// WC 6.4.0 to 6.4.1.
+			\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+			\Automattic\WooCommerce\Internal\Admin\Install::create_events();
+		} elseif ( class_exists( '\Automattic\WooCommerce\Admin\Install' ) ) {
+			// WC 4.0.0 to 6.3.1.
+			\Automattic\WooCommerce\Admin\Install::create_tables();
+			\Automattic\WooCommerce\Admin\Install::create_events();
+		}
 
 		$GLOBALS['wp_roles'] = null;
 		wp_roles();

--- a/UnitTests/Integration/bootstrap.php
+++ b/UnitTests/Integration/bootstrap.php
@@ -32,6 +32,13 @@ use WP_Syntex\Polylang_Phpunit\Bootstrap;
  *     }
  * }
  * @return void
+ *
+ * @phpstan-param array{
+ *     plugins?: array<bool|array{
+ *         group?: string,
+ *         init?: callable
+ *     }>
+ * } $args
  */
 function bootstrapSuite( $testsDir, $phpVersion, $args = [] ) {
 	$args      = array_merge(

--- a/UnitTests/Integration/bootstrap.php
+++ b/UnitTests/Integration/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Bootstraps the integration tests
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Integration
  */

--- a/UnitTests/Integration/bootstrap.php
+++ b/UnitTests/Integration/bootstrap.php
@@ -13,6 +13,7 @@ use WP_Syntex\Polylang_Phpunit\Bootstrap;
 /**
  * Bootstraps the integration testing environment with WordPress, plugins, and other dependencies.
  *
+ * @param  string       $rootDir    Path to the directory of the project.
  * @param  string       $testsDir   Path to the directory containing all tests.
  * @param  string       $phpVersion The PHP version required to run this test suite.
  * @param  array<mixed> $args       {
@@ -40,19 +41,20 @@ use WP_Syntex\Polylang_Phpunit\Bootstrap;
  *     }>
  * } $args
  */
-function bootstrapSuite( $testsDir, $phpVersion, $args = [] ) {
+function bootstrapSuite( $rootDir, $testsDir, $phpVersion, $args = [] ) {
 	$args      = array_merge(
 		[
 			'plugins' => [],
 		],
 		$args
 	);
-	$bootstrap = new Bootstrap( 'Integration', $testsDir, $phpVersion );
+	$bootstrap = new Bootstrap( 'Integration', $rootDir, $testsDir, $phpVersion );
 
 	$bootstrap->initTestSuite();
 
-	$wpPluginsDir = dirname( $testsDir ) . '/tmp/plugins/';
-	$wpThemesDir  = dirname( $testsDir ) . '/tmp/themes';
+	$rootDir      = rtrim( $rootDir, '/\\' );
+	$wpPluginsDir = "{$rootDir}/tmp/plugins/";
+	$wpThemesDir  = "{$rootDir}/tmp/themes";
 	$allPlugins   = []; // Plugins that will be loaded. Format: {pluginPath} => {initCallback} (empty string if no callback is needed).
 	$groups       = []; // Cache saying if groups are requested (with `--group=foo`). Format: {groupName} => {isRequested}.
 

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -245,6 +245,7 @@ trait TestCaseTrait {
 
 	/**
 	 * Returns the value of a private/protected property.
+	 * Note: overrides `Yoast\PHPUnitPolyfills\TestCases\TestCase::getPropertyValue()`.
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -99,68 +99,13 @@ trait TestCaseTrait {
 	/**
 	 * Makes a path relative to the project.
 	 *
-	 * @param string $path A normalized path (use `wp_normalize_path()`).
+	 * @param string $path A path.
 	 * @return string
 	 */
 	public static function makePathRelative( $path ) {
-		$rootPath   = self::normalizePath( WPSYNTEX_PROJECT_PATH );
-		$rootPath   = preg_quote( $rootPath, '@' );
+		$rootPath   = preg_quote( WPSYNTEX_PROJECT_PATH, '@' );
 		$resultPath = preg_replace( "@^$rootPath@", '', $path );
 		return is_string( $resultPath ) ? $resultPath : $path;
-	}
-
-	/**
-	 * Normalizes a filesystem path.
-	 * This is a copy of `wp_normalize_path()`, so it can be used in unit tests.
-	 *
-	 * On windows systems, replaces backslashes with forward slashes
-	 * and forces upper-case drive letters.
-	 * Allows for two leading slashes for Windows network shares, but
-	 * ensures that all other duplicate slashes are reduced to a single.
-	 *
-	 * @param string $path Path to normalize.
-	 * @return string Normalized path.
-	 */
-	public static function normalizePath( $path ) {
-		$wrapper = '';
-
-		if ( self::isStream( $path ) ) {
-			list( $wrapper, $path ) = explode( '://', $path, 2 );
-
-			$wrapper .= '://';
-		}
-
-		// Standardize all paths to use '/'.
-		$path = str_replace( '\\', '/', $path );
-
-		// Replace multiple slashes down to a singular, allowing for network shares having two slashes.
-		$path = (string) preg_replace( '|(?<=.)/+|', '/', $path );
-
-		// Windows paths should uppercase the drive letter.
-		if ( ':' === substr( $path, 1, 1 ) ) {
-			$path = ucfirst( $path );
-		}
-
-		return $wrapper . $path;
-	}
-
-	/**
-	 * Tests if a given path is a stream URL.
-	 * This is a copy of `wp_is_stream()`, so it can be used in unit tests.
-	 *
-	 * @param string $path The resource path or URL.
-	 * @return bool True if the path is a stream URL.
-	 */
-	public static function isStream( $path ) {
-		$scheme_separator = strpos( $path, '://' );
-
-		if ( false === $scheme_separator ) {
-			// $path isn't a stream.
-			return false;
-		}
-
-		$stream = substr( $path, 0, $scheme_separator );
-		return in_array( $stream, stream_get_wrappers(), true );
 	}
 
 	/**

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -49,10 +49,10 @@ trait TestCaseTrait {
 	/**
 	 * Returns the test data, if it exists, for this test class.
 	 *
-	 * @param  string $dirPath  Directory of the test class.
-	 * @param  string $fileName Test data filename without the `.php` extension.
-	 * @param  string $dataSet  Optional. Name of a subset in the data.
-	 * @return array<mixed>     Array of test data.
+	 * @param string $dirPath  Directory of the test class.
+	 * @param string $fileName Test data filename without the `.php` extension.
+	 * @param string $dataSet  Optional. Name of a subset in the data.
+	 * @return mixed[] Array of test data.
 	 */
 	public static function getTestData( $dirPath, $fileName, $dataSet = null ) {
 		$error_msg = 'Cannot get data with provider: ';
@@ -176,7 +176,7 @@ trait TestCaseTrait {
 	/**
 	 * Prepares data for log.
 	 *
-	 * @param  mixed $data Data to log.
+	 * @param mixed $data Data to log.
 	 * @return string
 	 */
 	public static function varExport( $data ) {
@@ -203,8 +203,8 @@ trait TestCaseTrait {
 	/**
 	 * Returns the errors from a `WP_Error` object.
 	 *
-	 * @param  WP_Error|mixed $wpError A `WP_Error` object.
-	 * @return array<mixed>
+	 * @param WP_Error|mixed $wpError A `WP_Error` object.
+	 * @return mixed[]
 	 */
 	public static function getErrors( $wpError ) {
 		if ( ! $wpError instanceof WP_Error ) {
@@ -219,9 +219,9 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *
-	 * @param  object|string $objInstance  Class name for a static property, or instance for an instance property.
-	 * @param  string        $propertyName Property name for which to gain access.
-	 * @return mixed                       The previous value of the property.
+	 * @param object|string $objInstance  Class name for a static property, or instance for an instance property.
+	 * @param string        $propertyName Property name for which to gain access.
+	 * @return mixed The previous value of the property.
 	 */
 	public static function resetPropertyValue( $objInstance, $propertyName ) {
 		return self::setPropertyValue( $objInstance, $propertyName, null );
@@ -232,10 +232,10 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *
-	 * @param  object|string $objInstance  Class name for a static property, or instance for an instance property.
-	 * @param  string        $propertyName Property name for which to gain access.
-	 * @param  mixed         $value        The value to set to the property.
-	 * @return mixed                       The previous value of the property.
+	 * @param object|string $objInstance  Class name for a static property, or instance for an instance property.
+	 * @param string        $propertyName Property name for which to gain access.
+	 * @param mixed         $value        The value to set to the property.
+	 * @return mixed The previous value of the property.
 	 */
 	public static function setPropertyValue( $objInstance, $propertyName, $value ) {
 		$ref = self::getReflectiveProperty( $objInstance, $propertyName );
@@ -258,8 +258,8 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *
-	 * @param  object|string $objInstance  Class name for a static property, or instance for an instance property.
-	 * @param  string        $propertyName Property name for which to gain access.
+	 * @param object|string $objInstance  Class name for a static property, or instance for an instance property.
+	 * @param string        $propertyName Property name for which to gain access.
 	 * @return mixed
 	 */
 	public static function getPropertyValue( $objInstance, $propertyName ) {
@@ -277,10 +277,10 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception upon failure.
 	 *
-	 * @param  object|string $objInstance Class name for a static method, or instance for an instance method.
-	 * @param  string        $methodName  Method name for which to gain access.
-	 * @param  array<mixed>  $args        List of args to pass to the method.
-	 * @return mixed                      The method result.
+	 * @param object|string $objInstance Class name for a static method, or instance for an instance method.
+	 * @param string        $methodName  Method name for which to gain access.
+	 * @param mixed[]       $args        List of args to pass to the method.
+	 * @return mixed The method result.
 	 */
 	public static function invokeMethod( $objInstance, $methodName, $args = [] ) {
 		if ( is_string( $objInstance ) ) {
@@ -300,8 +300,8 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if method does not exist.
 	 *
-	 * @param  object|string $objInstance Class name for a static method, or instance for an instance method.
-	 * @param  string        $methodName  Method name for which to gain access.
+	 * @param object|string $objInstance Class name for a static method, or instance for an instance method.
+	 * @param string        $methodName  Method name for which to gain access.
 	 * @return ReflectionMethod
 	 */
 	public static function getReflectiveMethod( $objInstance, $methodName ) {
@@ -316,8 +316,8 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *
-	 * @param  object|string $objInstance  Class name for a static property, or instance for an instance property.
-	 * @param  string        $propertyName Property name for which to gain access.
+	 * @param object|string $objInstance  Class name for a static property, or instance for an instance property.
+	 * @param string        $propertyName Property name for which to gain access.
 	 * @return ReflectionProperty
 	 */
 	public static function getReflectiveProperty( $objInstance, $propertyName ) {
@@ -332,9 +332,9 @@ trait TestCaseTrait {
 	 *
 	 * @throws ReflectionException Throws an exception if property does not exist.
 	 *
-	 * @param  object|string $objInstance  Class name for a static property, or instance for an instance property.
-	 * @param  string        $propertyName Property name for which to gain access.
-	 * @param  mixed         $value        The value to set for the property.
+	 * @param object|string $objInstance  Class name for a static property, or instance for an instance property.
+	 * @param string        $propertyName Property name for which to gain access.
+	 * @param mixed         $value        The value to set for the property.
 	 * @return ReflectionProperty
 	 */
 	public static function setReflectiveProperty( $objInstance, $propertyName, $value ) {

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Generic trait for all tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit
  */

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -19,16 +19,6 @@ use WP_Error;
 trait TestCaseTrait {
 
 	/**
-	 * Replacement values for `getTestData()`.
-	 *
-	 * @var array<string|array<string>>
-	 */
-	protected static $testDataReplacements = [
-		'tests'    => [ '/Integration/', '/Unit/' ],
-		'fixtures' => '/Fixtures/',
-	];
-
-	/**
 	 * An instanciated `__return_true()`.
 	 *
 	 * @return bool
@@ -61,7 +51,7 @@ trait TestCaseTrait {
 			self::fail( $error_msg . '$dirPath and/or $fileName not provided.' );
 		}
 
-		$dirPath  = str_replace( static::$testDataReplacements['tests'], static::$testDataReplacements['fixtures'], self::normalizePath( "{$dirPath}/" ) );
+		$dirPath  = str_replace( \WPSYNTEX_TESTS_PATH, \WPSYNTEX_FIXTURES_PATH, self::normalizePath( "{$dirPath}/" ) );
 		$dirPath  = rtrim( $dirPath, '\\/' );
 		$dataPath = "$dirPath/{$fileName}.php";
 

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -51,7 +51,7 @@ trait TestCaseTrait {
 			self::fail( $error_msg . '$dirPath and/or $fileName not provided.' );
 		}
 
-		$dirPath  = str_replace( \WPSYNTEX_TESTS_PATH, \WPSYNTEX_FIXTURES_PATH, self::normalizePath( "{$dirPath}/" ) );
+		$dirPath  = str_replace( \WPSYNTEX_TESTS_PATH, \WPSYNTEX_FIXTURES_PATH, $dirPath . DIRECTORY_SEPARATOR );
 		$dirPath  = rtrim( $dirPath, '\\/' );
 		$dataPath = "$dirPath/{$fileName}.php";
 

--- a/UnitTests/Unit/AbstractTestCase.php
+++ b/UnitTests/Unit/AbstractTestCase.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Test Case for all of the unit tests.
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Unit
  */

--- a/UnitTests/Unit/bootstrap.php
+++ b/UnitTests/Unit/bootstrap.php
@@ -13,10 +13,11 @@ use WP_Syntex\Polylang_Phpunit\Bootstrap;
 /**
  * Bootstraps the unit testing environment.
  *
+ * @param  string $rootDir    Path to the directory of the project.
  * @param  string $testsDir   Path to the directory containing all tests.
  * @param  string $phpVersion The PHP version required to run this test suite.
  * @return void
  */
-function bootstrapSuite( $testsDir, $phpVersion ) {
-	( new Bootstrap( 'unit', $testsDir, $phpVersion ) )->initTestSuite();
+function bootstrapSuite( $rootDir, $testsDir, $phpVersion ) {
+	( new Bootstrap( 'unit', $rootDir, $testsDir, $phpVersion ) )->initTestSuite();
 }

--- a/UnitTests/Unit/bootstrap.php
+++ b/UnitTests/Unit/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Bootstraps the unit tests
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit\Integration
  */

--- a/UnitTests/functions.php
+++ b/UnitTests/functions.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Various functions.
+ * php version 7.0
+ *
+ * @package WP_Syntex\Polylang_Phpunit
+ */
+
+namespace WP_Syntex\Polylang_Phpunit;
+
+/**
+ * Returns colors used in CLI.
+ *
+ * @see bin/colors.sh
+ *
+ * @return string[]
+ *
+ * @phpstan-return array{
+ *     info: non-falsy-string,
+ *     success: non-falsy-string,
+ *     error: non-falsy-string,
+ *     no_color: non-falsy-string
+ * }
+ */
+function getCliColors(): array {
+	return [
+		'info'     => "\033[0;36m",
+		'success'  => "\033[0;32m",
+		'error'    => "\033[0;31m",
+		'no_color' => "\033[0m",
+	];
+}

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,22 +4,20 @@
 # $1 string Whether to run composer install or update. '-u' or '--update' to update, anything else to install.
 # $2 string '--no-npm' to not run npm.
 
-if [[ "$1" = "-u" ]] || [[ "$1" = "--update" ]]; then
-	local COMPOSER_COMMAND='update'
-else
-	local COMPOSER_COMMAND='install'
-fi
-
 echo "Installing PHP packages..."
-rm -rf vendor/ # Make sure to remove all traces of development dependencies.
-composer $COMPOSER_COMMAND # Need update to ensure to have the latest version of the dependencies.
+# Make sure to remove all traces of development dependencies.
+rm -rf vendor
+# Update/Install to ensure to have the latest version of the dependencies.
+if [[ "$1" = "-u" ]] || [[ "$1" = "--update" ]]; then
+	composer update
+else
+	composer install
+fi
 
 if [[ '--no-npm' != $2 ]]; then
 	echo "Running build..."
-	npm install && npm run build # minify js and css files.
+	# Minify js and css files.
+	npm install && npm run build
 fi
 
 echo "Build done!"
-
-echo "Cleanup." # Discard composer.lock and package-lock.json changings to ensure they'll never be pushed on repository.
-git checkout -- composer.lock package-lock.json

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,6 +5,11 @@
 # $2 string '--no-npm' to not run npm.
 
 echo "Installing PHP packages..."
+
+# Include color values (must be done before `rm -rf vendor`).
+PARENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+. "$PARENT_DIR/colors.sh"
+
 # Make sure to remove all traces of development dependencies.
 rm -rf vendor
 # Update/Install to ensure to have the latest version of the dependencies.
@@ -20,4 +25,4 @@ if [[ '--no-npm' != $2 ]]; then
 	npm install && npm run build
 fi
 
-echo "Build done!"
+echo "${SUCCESS_C}Build done!${NO_C}"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 # Builds the project (Composer, npm).
 #
 # $1 string Whether to run composer install or update. '-u' or '--update' to update, anything else to install.

--- a/bin/colors.sh
+++ b/bin/colors.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Colors used to print messages to stdout.
+if [[ "$(type -t tput)" == 'file' ]] && [[ $(tput colors) ]]; then
+	INFO_C="$(tput setaf 6)"
+	SUCCESS_C="$(tput setaf 2)"
+	ERROR_C="$(tput setaf 1)"
+	NO_C="$(tput sgr0)"
+else
+	INFO_C='\033[0;36m'
+	SUCCESS_C='\033[0;32m'
+	ERROR_C='\033[0;31m'
+	NO_C='\033[0m'
+fi

--- a/bin/colors.sh
+++ b/bin/colors.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Colors used to print messages to stdout.
+# See `UnitTests/functions.php`.
 if [[ "$(type -t tput)" == 'file' ]] && [[ $(tput colors) ]]; then
 	INFO_C="$(tput setaf 6)"
 	SUCCESS_C="$(tput setaf 2)"

--- a/bin/distribute.sh
+++ b/bin/distribute.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 # Creates a zip file of the project.
 #
 # $1 string A custom plugin slug. Optional.

--- a/bin/install-wp-suite.sh
+++ b/bin/install-wp-suite.sh
@@ -6,14 +6,8 @@ INSTALL_DIR="$( cd "$(dirname "$PARENT_DIR")" ; pwd -P )/tmp"
 WP_CORE_DIR="$INSTALL_DIR/wordpress"
 WP_TESTS_DIR="$INSTALL_DIR/wordpress-tests-lib"
 
-# Colors used to print messages to stdout.
-if [[ "$(type -t tput)" == 'file' ]] && [[ $(tput colors) ]]; then
-	INFO_C="$(tput setaf 6)"
-	NO_C="$(tput sgr0)"
-else
-	INFO_C='\033[0;36m'
-	NO_C='\033[0m'
-fi
+# Include color values.
+. "$PARENT_DIR/colors.sh"
 
 # Installs the WordPress test suite by using a local config file.
 # Ex: installWpSuite latest true

--- a/bin/install-wp-suite.sh
+++ b/bin/install-wp-suite.sh
@@ -2,9 +2,8 @@
 
 WORKING_DIR="$PWD"
 PARENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-INSTALL_DIR="$( cd "$(dirname "$PARENT_DIR")" ; pwd -P )/tmp"
-WP_CORE_DIR="$INSTALL_DIR/wordpress"
-WP_TESTS_DIR="$INSTALL_DIR/wordpress-tests-lib"
+WP_CORE_DIR="$WORKING_DIR/tmp/wordpress"
+WP_TESTS_DIR="$WORKING_DIR/tmp/wordpress-tests-lib"
 
 # Include color values.
 . "$PARENT_DIR/colors.sh"

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -11,18 +11,8 @@ DEPS_DIR="$WORKING_DIR/tmp"
 WP_PLUGINS_DIR="$DEPS_DIR/plugins"
 WP_THEMES_DIR="$DEPS_DIR/themes"
 
-# Colors used to print messages to stdout.
-if [[ "$(type -t tput)" == 'file' ]] && [[ $(tput colors) ]]; then
-	INFO_C="$(tput setaf 6)"
-	SUCCESS_C="$(tput setaf 2)"
-	ERROR_C="$(tput setaf 1)"
-	NO_C="$(tput sgr0)"
-else
-	INFO_C='\033[0;36m'
-	SUCCESS_C='\033[0;32m'
-	ERROR_C='\033[0;31m'
-	NO_C='\033[0m'
-fi
+# Include color values.
+. "$PARENT_DIR/colors.sh"
 
 # Include download tools.
 . "$PARENT_DIR/generic-download-tools.sh"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
 	"type": "library",
 	"minimum-stability": "dev",
 	"config": {
-		"sort-packages": true
+		"sort-packages": true,
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"require": {
 		"php": ">=5.6",

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
 			"@cs",
 			"@stan"
 		],
-		"install-suite": "bin/install-wp-suite.sh",
-		"install-suite-with-db": "bin/install-wp-suite.sh latest true"
+		"install-suite": "bash bin/install-wp-suite.sh",
+		"install-suite-with-db": "bash bin/install-wp-suite.sh latest true"
 	},
 	"scripts-descriptions": {
 		"cs": "Runs PHPCS linter.",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
 			"WP_Syntex\\Polylang_Phpunit\\": "UnitTests/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"WP_Syntex\\Polylang_Phpunit\\Fixtures\\": "Fixtures/"
+		}
+	},
 	"scripts": {
 		"cs": "vendor/bin/phpcs",
 		"stan": "vendor/bin/phpstan analyze --memory-limit=1G",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.0",
 		"cheprasov/php-cli-args": "^3.0",
 		"symfony/console": "^3.4 || ^4.4",
 		"yoast/wp-test-utils": "^1.0.0"

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Bootstraps PHPStan
+ * php version 5.6
+ *
+ * @package WP_Syntex\Polylang_Phpunit
+ */
+
+define( 'WPSYNTEX_PROJECT_PATH', __DIR__ . DIRECTORY_SEPARATOR );
+define( 'WPSYNTEX_TESTS_PATH', WPSYNTEX_PROJECT_PATH . 'UnitTests' . DIRECTORY_SEPARATOR . 'Integration' . DIRECTORY_SEPARATOR );
+define( 'WPSYNTEX_FIXTURES_PATH', WPSYNTEX_PROJECT_PATH . 'UnitTests' . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR );
+define( 'WPSYNTEX_TESTSUITE_PATH', WPSYNTEX_PROJECT_PATH . 'tmp/wordpress-tests-lib' . DIRECTORY_SEPARATOR );
+define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', WPSYNTEX_PROJECT_PATH . 'vendor/yoast/phpunit-polyfills/' );
+define( 'ABSPATH', WPSYNTEX_PROJECT_PATH . 'tmp/wordpress-tests-lib' . DIRECTORY_SEPARATOR );
+define( 'WPSYNTEX_IS_TESTING', true );

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Bootstraps PHPStan
- * php version 5.6
+ * php version 7.0
  *
  * @package WP_Syntex\Polylang_Phpunit
  */

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,9 @@ includes:
 	- vendor/wpsyntex/polylang-phpstan/extension.neon
 parameters:
 	level: max
+	treatPhpDocTypesAsCertain: false
 	paths:
+		- %currentWorkingDirectory%/Fixtures
 		- %currentWorkingDirectory%/UnitTests
 	bootstrapFiles:
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
@@ -12,3 +14,9 @@ parameters:
 		- tmp/wordpress-tests-lib/includes
 	ignoreErrors:
 		- '#^Constant WPSYNTEX_PROJECT_PATH not found\.$#'
+
+		# Ignored because false positive: $pluginArgs['group'] cannot be a string in `foreach ( $pluginArgs['group'] as $group )`.
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: UnitTests/Integration/bootstrap.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,6 +14,8 @@ parameters:
 		- tmp/wordpress-tests-lib/includes
 	ignoreErrors:
 		- '#^Constant WPSYNTEX_PROJECT_PATH not found\.$#'
+		- '#^Constant WPSYNTEX_FIXTURES_PATH not found\.$#'
+		- '#^Constant WPSYNTEX_TESTS_PATH not found\.$#'
 
 		# Ignored because false positive: $pluginArgs['group'] cannot be a string in `foreach ( $pluginArgs['group'] as $group )`.
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,15 +8,12 @@ parameters:
 		- %currentWorkingDirectory%/Fixtures
 		- %currentWorkingDirectory%/UnitTests
 	bootstrapFiles:
+		- phpstan-bootstrap.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
 	scanDirectories:
 		- tmp/wordpress-tests-lib/includes
 	ignoreErrors:
-		- '#^Constant WPSYNTEX_PROJECT_PATH not found\.$#'
-		- '#^Constant WPSYNTEX_FIXTURES_PATH not found\.$#'
-		- '#^Constant WPSYNTEX_TESTS_PATH not found\.$#'
-
 		# Ignored because false positive: $pluginArgs['group'] cannot be a string in `foreach ( $pluginArgs['group'] as $group )`.
 		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|string supplied for foreach, only iterables are supported\\.$#"


### PR DESCRIPTION
This PR brings various improvements after trying to use this project for PLL Pro's tests.

## WP's test suite location

WP's test suite is not installed in this project anymore, but in the client's `tmp` folder instead. This prevents to have to:
- re-install the suite each time this project is updated,
- search deep inside the `vendor` folder when we need to access WP's files.

## Folders

- A `$rootDir` has been added to `WP_Syntex\Polylang_Phpunit\Bootstrap::__construct()` (and to the `bootstrapSuite()` functions). This allows more flexibility, the "tests dir" not being forced to be 1 level down the "root dir" (project dir) anymore (see the constants `WPSYNTEX_PROJECT_PATH` and `WPSYNTEX_TESTS_PATH`).
- New constant `WPSYNTEX_TESTSUITE_PATH` that contains the path to the test suite: `tmp/wordpress-tests-lib`. It is used in 1 test class in PLL Pro (`PLL_Translation_Walker_Blocks_Test`).

## Tools

- A 3rd parameter has been added to `WP_Syntex\Polylang_Phpunit\TestCaseTrait::getTestData()` to replicate what is already done in PLL Pro. It allows to select only a subset instead of the entire data set.

## Bash scripts

- Fix a few things.
- New file `colors.sh` containing color definitions for the messages.
- Harmonized messages and added some colors to error and success messages.

## PHPStan

- A class `DummyTestCase` has been added so PHPStan can cover `WP_Syntex\Polylang_Phpunit\Integration\TestCaseTrait`.
- A `(array)` cast has been added in `WP_Syntex\Polylang_Phpunit\Bootstrap::isGroup()`.
- Some constants have been added to PHPStan's ignore list.

## PHP 7.0

Bumped from php 5.6 to 7.0.

## Readme

We make typo.