### PR TITLE
Fix working dir path for windows OS

### DIFF
--- a/bin/install-wp-suite.sh
+++ b/bin/install-wp-suite.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-WORKING_DIR="$PWD"
+# Is cmd command available ? Windows only.
+if [ -x "$(command -v cmd)" ]; then
+	# pwd -W option available in Git bash for windows.
+	# We get current folder path with slash as separator.
+	WORKING_DIR=$(pwd -W)
+else
+	WORKING_DIR="$PWD"
+fi
+
 PARENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 WP_CORE_DIR="$WORKING_DIR/tmp/wordpress"
 WP_TESTS_DIR="$WORKING_DIR/tmp/wordpress-tests-lib"

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -114,8 +114,9 @@ install_test_suite() {
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# Escape `:` character use as volume separator on windows file path and make sed command work with the same delimiter.
 		# remove all forward slashes in the end
-		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		WP_CORE_DIR=$(echo ${WP_CORE_DIR//:/\\:} | sed "s:/\+$::")
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
- Add condition to check Windows OS and use `pwd -W` command instead of `$PWD` environment variable to get the correct current folder windows path with `/` separator
- Escape `:` character in the `WP_CORE_DIR` to make the string path usable in the sed replacement command which also uses  `:` character as its delimiter