### PR TITLE
Prevent Patchwork from printing text during tests run.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -91,8 +91,6 @@ install_wp() {
 		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
-
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
## What?
Patchwork prints `;\Patchwork\CodeManipulation\Stream::reinstateWrapper();` when running PHPUnit. And also seems to slow down tests (but it might be subjective 😅).

## How?
Follows what has been [done](https://github.com/polylang/polylang/commit/21bb5b3987ba41a90acd8b3b5da4eb203e3cc85e) in Polylang and remove `db.php` file when installing WordPress in tests.