### PR TITLE
Include WP's `compat.php` file for unit tests

### DIFF
--- a/UnitTests/Bootstrap.php
+++ b/UnitTests/Bootstrap.php
@@ -115,6 +115,12 @@ class Bootstrap {
 			 * Give access to tests_add_filter() function.
 			 */
 			require_once $this->getWpTestsDir() . '/includes/functions.php';
+		} else {
+			/**
+			 * Unit tests:
+			 * Give access to WP's compatibility functions like `str_ends_with()`.
+			 */
+			require_once  ABSPATH . 'wp-includes/compat.php';
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/polylang/polylang-pro/issues/2020.
Required by https://github.com/polylang/polylang-pro/pull/2080.

This allows functions like `str_ends_with()` to be used in unit tests, even with PHP < 8.0.