### PR TITLE
Fix theme download failure

### DIFF
--- a/bin/generic-download-tools.sh
+++ b/bin/generic-download-tools.sh
@@ -17,8 +17,8 @@ getContent() {
 # $2 string Destination path to download the file to.
 download() {
 	if [[ `which curl` ]]; then
-		curl -sL "$1" > "$2";
+		curl -sL --proto '=https' --max-redirs 2 "$1" > "$2";
 	elif [[ `which wget` ]]; then
-		wget -nv -O "$2" "$1"
+		wget --https-only -nv --max-redirect=2 -O "$2" "$1"
 	fi
 }

--- a/bin/generic-download-tools.sh
+++ b/bin/generic-download-tools.sh
@@ -17,8 +17,8 @@ getContent() {
 # $2 string Destination path to download the file to.
 download() {
 	if [[ `which curl` ]]; then
-		curl -sL --proto '=https' --max-redirs 2 "$1" > "$2";
+		curl -sL --proto '=https' --max-redirs 1 "$1" > "$2";
 	elif [[ `which wget` ]]; then
-		wget --https-only -nv --max-redirect=2 -O "$2" "$1"
+		wget --https-only -nv --max-redirect=1 -O "$2" "$1"
 	fi
 }

--- a/bin/generic-download-tools.sh
+++ b/bin/generic-download-tools.sh
@@ -5,9 +5,9 @@
 # $1 string Contents URL.
 getContent() {
 	if [[ `which curl` ]]; then
-		curl -s "$1";
+		curl -s --proto '=https' "$1";
 	elif [[ `which wget` ]]; then
-		wget "$1" -q -O -
+		wget --https-only "$1" -q -O -
 	fi
 }
 

--- a/bin/generic-download-tools.sh
+++ b/bin/generic-download-tools.sh
@@ -17,7 +17,7 @@ getContent() {
 # $2 string Destination path to download the file to.
 download() {
 	if [[ `which curl` ]]; then
-		curl -s "$1" > "$2";
+		curl -sL "$1" > "$2";
 	elif [[ `which wget` ]]; then
 		wget -nv -O "$2" "$1"
 	fi

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -48,13 +48,20 @@ downloadPluginFromRepository() {
 	fi
 
 	# Download the plugin.
+	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
+
 	if [[ $VERSION == 'trunk' ]]; then
-		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.zip $DOWNLOADS_DIR/$PLUGIN_SLUG.zip
+		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.zip $ZIP_PATH
 	else
-		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.$VERSION.zip $DOWNLOADS_DIR/$PLUGIN_SLUG.zip
+		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.$VERSION.zip $ZIP_PATH
 	fi
 
-	unzip -q $DOWNLOADS_DIR/$PLUGIN_SLUG.zip -d $WP_PLUGINS_DIR
+	if [[ ! -f "$ZIP_PATH" ]]; then
+		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
+		return
+	fi
+
+	unzip -q $ZIP_PATH -d $WP_PLUGINS_DIR
 
 	if [[ $? == 0 ]] ; then
 		messageSuccessfullyInstalled "$PLUGIN_SLUG $VERSION"
@@ -131,8 +138,16 @@ license $PLUGIN_SLUG:none"
 	fi
 
 	# Download the plugin.
-	download $URL $DOWNLOADS_DIR/$PLUGIN_SLUG.zip
-	unzip -q $DOWNLOADS_DIR/$PLUGIN_SLUG.zip -d $WP_PLUGINS_DIR
+	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
+
+	download $URL $ZIP_PATH
+
+	if [[ ! -f "$ZIP_PATH" ]]; then
+		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
+		return
+	fi
+
+	unzip -q $ZIP_PATH -d $WP_PLUGINS_DIR
 
 	local VERSION=$(getPackageVersion $INFO)
 
@@ -308,8 +323,17 @@ downloadThemeFromRepository() {
 		return
 	fi
 
-	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $DOWNLOADS_DIR/$THEME_SLUG.zip
-	unzip -q $DOWNLOADS_DIR/$THEME_SLUG.zip -d $WP_THEMES_DIR
+	# Download the plugin.
+	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
+
+	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $ZIP_PATH
+
+	if [[ ! -f "$ZIP_PATH" ]]; then
+		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
+		return
+	fi
+
+	unzip -q $ZIP_PATH -d $WP_THEMES_DIR
 
 	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
 

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -324,12 +324,12 @@ downloadThemeFromRepository() {
 	fi
 
 	# Download the plugin.
-	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
+	local ZIP_PATH="$DOWNLOADS_DIR/$THEME_SLUG.zip"
 
 	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $ZIP_PATH
 
 	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
+		messageInstallationFailure "$THEME_SLUG $VERSION"
 		return
 	fi
 

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -139,6 +139,7 @@ license $PLUGIN_SLUG:none"
 
 	# Download the plugin.
 	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
+	local VERSION=$(getPackageVersion $INFO)
 
 	download $URL $ZIP_PATH
 
@@ -148,8 +149,6 @@ license $PLUGIN_SLUG:none"
 	fi
 
 	unzip -q $ZIP_PATH -d $WP_PLUGINS_DIR
-
-	local VERSION=$(getPackageVersion $INFO)
 
 	if [[ $? == 0 ]] ; then
 		messageSuccessfullyInstalled "$PLUGIN_SLUG $VERSION"
@@ -325,6 +324,7 @@ downloadThemeFromRepository() {
 
 	# Download the plugin.
 	local ZIP_PATH="$DOWNLOADS_DIR/$THEME_SLUG.zip"
+	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
 
 	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $ZIP_PATH
 
@@ -334,8 +334,6 @@ downloadThemeFromRepository() {
 	fi
 
 	unzip -q $ZIP_PATH -d $WP_THEMES_DIR
-
-	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
 
 	if [[ $? == 0 ]] ; then
 		messageSuccessfullyInstalled "$THEME_SLUG $VERSION"

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -56,18 +56,7 @@ downloadPluginFromRepository() {
 		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.$VERSION.zip $ZIP_PATH
 	fi
 
-	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
-		return
-	fi
-
-	unzip -q $ZIP_PATH -d $WP_PLUGINS_DIR
-
-	if [[ $? == 0 ]] ; then
-		messageSuccessfullyInstalled "$PLUGIN_SLUG $VERSION"
-	else
-		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
-	fi ;
+	maybeUnzip $ZIP_PATH $WP_PLUGINS_DIR "$PLUGIN_SLUG $VERSION"
 }
 
 # Downloads a plugin distributed by a EDD install.
@@ -143,18 +132,7 @@ license $PLUGIN_SLUG:none"
 
 	download $URL $ZIP_PATH
 
-	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
-		return
-	fi
-
-	unzip -q $ZIP_PATH -d $WP_PLUGINS_DIR
-
-	if [[ $? == 0 ]] ; then
-		messageSuccessfullyInstalled "$PLUGIN_SLUG $VERSION"
-	else
-		messageInstallationFailure "$PLUGIN_SLUG $VERSION"
-	fi ;
+	maybeUnzip $ZIP_PATH $WP_PLUGINS_DIR "$PLUGIN_SLUG $VERSION"
 }
 
 # Downloads Polylang for WooCommerce.
@@ -443,4 +421,29 @@ messageSuccessfullyInstalled() {
 # return string
 messageInstallationFailure() {
 	formatMessage "${ERROR_C}$1${NO_C} installation failure."
+}
+
+# Unzips a file.
+# Writes to stdout whether the operation has been successful or not.
+#
+# $1 string The path to the zip file.
+# $2 string The path to the destination folder.
+# $3 string The name of the package being unzipped (usually "{slug} {version}").
+maybeUnzip() {
+	local ZIP_PATH="$1"
+	local DESTINATION_PATH="$2"
+	local NAME="$3"
+
+	if [[ ! -f "$ZIP_PATH" ]]; then
+		messageInstallationFailure $NAME
+		return
+	fi
+
+	unzip -q $ZIP_PATH -d $DESTINATION_PATH
+
+	if [[ $? == 0 ]] ; then
+		messageSuccessfullyInstalled $NAME
+	else
+		messageInstallationFailure $NAME
+	fi ;
 }

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -116,9 +116,9 @@ license $PLUGIN_SLUG:none"
 	local HEADERS='Content-Type: application/x-www-form-urlencoded;Cache-Control: no-cache;Accept: application/json;Connection: keep-alive'
 
 	if [[ `which curl` ]]; then
-		local INFO=$(curl -d "$PARAMS" -H "$HADERS" -X POST -s "$URL")
+		local INFO=$(curl -d "$PARAMS" -H "$HEADERS" -X POST -s "$URL")
 	elif [[ `which wget` ]]; then
-		local INFO=$(wget --post-data "$PARAMS" --header "$HADERS" "$URL" -q -O -)
+		local INFO=$(wget --post-data "$PARAMS" --header "$HEADERS" "$URL" -q -O -)
 	fi
 
 	local URL=$(getPackageUrl "$INFO")

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -324,16 +324,22 @@ downloadThemeFromRepository() {
 
 	# Download the plugin.
 	local ZIP_PATH="$DOWNLOADS_DIR/$THEME_SLUG.zip"
-	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
 
 	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $ZIP_PATH
 
 	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure "$THEME_SLUG $VERSION"
+		messageInstallationFailure $THEME_SLUG
 		return
 	fi
 
 	unzip -q $ZIP_PATH -d $WP_THEMES_DIR
+
+	if [[ ! -f "$WP_THEMES_DIR/$THEME_SLUG/style.css" ]]; then
+		messageInstallationFailure $THEME_SLUG
+		return
+	fi
+
+	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
 
 	if [[ $? == 0 ]] ; then
 		messageSuccessfullyInstalled "$THEME_SLUG $VERSION"

--- a/bin/wp-download-tools.sh
+++ b/bin/wp-download-tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TMPDIR=${TMPDIR-/tmp}
-TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+TMPDIR=$(echo "$TMPDIR" | sed -e "s/\/$//")
 DOWNLOADS_DIR="$TMPDIR/downloads"
 
 PARENT_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
@@ -18,8 +18,8 @@ WP_THEMES_DIR="$DEPS_DIR/themes"
 . "$PARENT_DIR/generic-download-tools.sh"
 
 # Create the downloads folder.
-mkdir -p $DOWNLOADS_DIR
-mkdir -p $DEPS_DIR
+mkdir -p "$DOWNLOADS_DIR"
+mkdir -p "$DEPS_DIR"
 
 # Downloads a plugin from the repository.
 # Ex: downloadPluginFromRepository woocommerce
@@ -51,12 +51,12 @@ downloadPluginFromRepository() {
 	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
 
 	if [[ $VERSION == 'trunk' ]]; then
-		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.zip $ZIP_PATH
+		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.zip "$ZIP_PATH"
 	else
-		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.$VERSION.zip $ZIP_PATH
+		download https://downloads.wordpress.org/plugin/$PLUGIN_SLUG.$VERSION.zip "$ZIP_PATH"
 	fi
 
-	maybeUnzip $ZIP_PATH $WP_PLUGINS_DIR "$PLUGIN_SLUG $VERSION"
+	maybeUnzip "$ZIP_PATH" "$WP_PLUGINS_DIR" "$PLUGIN_SLUG $VERSION"
 }
 
 # Downloads a plugin distributed by a EDD install.
@@ -128,11 +128,11 @@ license $PLUGIN_SLUG:none"
 
 	# Download the plugin.
 	local ZIP_PATH="$DOWNLOADS_DIR/$PLUGIN_SLUG.zip"
-	local VERSION=$(getPackageVersion $INFO)
+	local VERSION=$(getPackageVersion "$INFO")
 
-	download $URL $ZIP_PATH
+	download "$URL" "$ZIP_PATH"
 
-	maybeUnzip $ZIP_PATH $WP_PLUGINS_DIR "$PLUGIN_SLUG $VERSION"
+	maybeUnzip "$ZIP_PATH" "$WP_PLUGINS_DIR" "$PLUGIN_SLUG $VERSION"
 }
 
 # Downloads Polylang for WooCommerce.
@@ -161,7 +161,7 @@ downloadPolylangForWoocommerce() {
 	composer install --no-dev
 
 	if [[ ! $PLLWC_VERSION ]]; then
-		PLLWC_VERSION=$(getVersionFromPluginFile $PLUGIN_FILE)
+		PLLWC_VERSION=$(getVersionFromPluginFile "$PLUGIN_FILE")
 	fi
 
 	messageSuccessfullyInstalled "$PLUGIN_DIR $PLLWC_VERSION"
@@ -197,7 +197,7 @@ downloadPolylangPro() {
 	fi
 
 	if [[ ! $PLL_VERSION ]]; then
-		PLL_VERSION=$(getVersionFromPluginFile $PLUGIN_FILE)
+		PLL_VERSION=$(getVersionFromPluginFile "$PLUGIN_FILE")
 	fi
 
 	messageSuccessfullyInstalled "$PLUGIN_DIR $PLL_VERSION"
@@ -303,21 +303,21 @@ downloadThemeFromRepository() {
 	# Download the plugin.
 	local ZIP_PATH="$DOWNLOADS_DIR/$THEME_SLUG.zip"
 
-	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip $ZIP_PATH
+	download https://downloads.wordpress.org/theme/$THEME_SLUG.zip "$ZIP_PATH"
 
 	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure $THEME_SLUG
+		messageInstallationFailure "$THEME_SLUG"
 		return
 	fi
 
-	unzip -q $ZIP_PATH -d $WP_THEMES_DIR
+	unzip -q "$ZIP_PATH" -d "$WP_THEMES_DIR"
 
 	if [[ ! -f "$WP_THEMES_DIR/$THEME_SLUG/style.css" ]]; then
-		messageInstallationFailure $THEME_SLUG
+		messageInstallationFailure "$THEME_SLUG"
 		return
 	fi
 
-	local VERSION=$(getVersionFromThemeFile $THEME_SLUG)
+	local VERSION=$(getVersionFromThemeFile "$THEME_SLUG")
 
 	if [[ $? == 0 ]] ; then
 		messageSuccessfullyInstalled "$THEME_SLUG $VERSION"
@@ -435,15 +435,15 @@ maybeUnzip() {
 	local NAME="$3"
 
 	if [[ ! -f "$ZIP_PATH" ]]; then
-		messageInstallationFailure $NAME
+		messageInstallationFailure "$NAME"
 		return
 	fi
 
-	unzip -q $ZIP_PATH -d $DESTINATION_PATH
+	unzip -q "$ZIP_PATH" -d "$DESTINATION_PATH"
 
 	if [[ $? == 0 ]] ; then
-		messageSuccessfullyInstalled $NAME
+		messageSuccessfullyInstalled "$NAME"
 	else
-		messageInstallationFailure $NAME
+		messageInstallationFailure "$NAME"
 	fi ;
 }


### PR DESCRIPTION
Themes from the repository use a redirection.
Ex: `https://downloads.wordpress.org/theme/twentyfourteen.zip` currently redirects (302) to `https://downloads.wordpress.org/theme/twentyfourteen.4.1.zip`.

This breaks our current `download` bash function because it doesn't allow redirects when using `curl`.

This PR's main aim is to fix this issue by allowing redirections with `curl`. Note: if `wget` is used (because `curl` isn't available), redirections are already allowed.

Also in this PR:
- Don't try to unzip a file that doesn't exist: display an error message directly if a download fails.
- Fix a typo in a variable name: when downloading a plugin from EDD, no headers were sent (it doesn't seem to be issue though).