### PR TITLE
Allow to use a more recent version of `symfony/console`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">=7.0",
 		"cheprasov/php-cli-args": "^3.0",
-		"symfony/console": "^3.4 || ^4.4",
+		"symfony/console": "^3.4 || ^4.4 || ^5.4 || ^6.4 || ^7.0",
 		"yoast/wp-test-utils": "^1.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
This prevents [this behat error](https://github.com/polylang/polylang/actions/runs/14864273129/job/41736982850) with php 8.3 and 8.4.

[Issue on Behat](https://github.com/Behat/Gherkin/issues/317).

The new `behat/gherkin` 4.13.0 triggers the error if `behat/behat` is < 3.20.0.

- [`behat/behat` 3.20.0](https://packagist.org/packages/behat/behat#v3.20.0) requires `symfony/console ^5.4 || ^6.4 || ^7.0`.
- This package was requiring `symfony/console ^3.4 || ^4.4`.

Composer error:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires behat/behat ^3.16 -> satisfiable by behat/behat[v3.16.0, ..., 3.x-dev].
    - Root composer.json requires wpsyntex/wp-phpunit dev-master -> satisfiable by wpsyntex/wp-phpunit[dev-master].
    - behat/behat v3.16.0 requires symfony/console ^5.4 || ^6.4 || ^7.0 -> satisfiable by symfony/console[v5.4.0-BETA1, ..., 5.4.x-dev, v6.4.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.3.x-dev].
    - Conclusion: don't install symfony/console v7.2.6 (conflict analysis result)
    - Conclusion: don't install symfony/console v7.3.0-BETA1 (conflict analysis result)
    - Conclusion: don't install behat/behat v3.19.0 (conflict analysis result)
    - Conclusion: don't install behat/behat v3.20.0 (conflict analysis result)
    - Conclusion: don't install behat/behat v3.21.1 (conflict analysis result)
    - Conclusion: don't install behat/behat v3.22.0 (conflict analysis result)
    - Conclusion: don't install symfony/console[v5.4.47] | install symfony/console[v4.4.49] (conflict analysis result)
    - Conclusion: don't install symfony/console[v5.4.0] | install symfony/console[v4.4.49] (conflict analysis result)
    - Conclusion: don't install symfony/console v4.4.49 (conflict analysis result)
    - Conclusion: don't install symfony/console v6.4.21 (conflict analysis result)
    - Conclusion: install symfony/console v4.4.26 (conflict analysis result)
    - You can only install one version of a package, so only one of these can be installed: symfony/console[v3.4.0-BETA1, ..., 3.4.x-dev, v4.4.0-BETA1, ..., 4.4.x-dev, v5.4.0-BETA1, ..., 5.4.x-dev, v6.4.0-BETA1, ..., 6.4.x-dev, v7.0.0-BETA1, ..., 7.3.x-dev].
```

Another solution would be to lock `behat/gherkin` at 4.12.0.