### PR TITLE
Always use 2 parameters for `ReflectionProperty::setValue()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Then you can create composer scripts like these ones for example:
         "install-tests-with-db": "Installs both the WordPress tests suite (with database creation) and the dependencies needed for integration tests, without creating the database.",
         "build": "Builds the project.",
         "build-update": "Builds the project (runs `composer update` instead of `composer install`).",
-        "dist": "Makes the zip file to distibute the project release."
+        "dist": "Makes the zip file to distribute the project release."
     }
 }
 ```

--- a/UnitTests/Integration/TestCaseTrait.php
+++ b/UnitTests/Integration/TestCaseTrait.php
@@ -87,7 +87,7 @@ trait TestCaseTrait {
 			remove_filter( 'pre_option_active_plugins', [ $this, 'filterActivePlugins' ] );
 		}
 
-		self::$model->clean_languages_cache(); // We must do it before database ROLLBACK otherwhise it is impossible to delete the transient.
+		self::$model->clean_languages_cache(); // We must do it before database ROLLBACK otherwise it is impossible to delete the transient.
 
 		$globals = [ 'current_screen', 'hook_suffix', 'wp_settings_errors', 'post_type', 'wp_scripts', 'wp_styles' ];
 
@@ -113,7 +113,7 @@ trait TestCaseTrait {
 	 * @throws InvalidArgumentException If language is not created.
 	 *
 	 * @param  string       $locale Language locale.
-	 * @param  array<mixed> $args   Allows to optionnally override the default values for the language.
+	 * @param  array<mixed> $args   Allows to optionally override the default values for the language.
 	 * @return void
 	 */
 	protected static function createLanguage( $locale, $args = [] ) {

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -182,7 +182,7 @@ trait TestCaseTrait {
 		} else {
 			$previousValue = $ref->getValue();
 			// Static property.
-			$ref->setValue( $value );
+			$ref->setValue( null, $value );
 		}
 
 		return $previousValue;
@@ -281,7 +281,7 @@ trait TestCaseTrait {
 			$ref->setValue( $objInstance, $value );
 		} else {
 			// Static property.
-			$ref->setValue( $value );
+			$ref->setValue( null, $value );
 		}
 
 		$ref->setAccessible( false );

--- a/UnitTests/TestCaseTrait.php
+++ b/UnitTests/TestCaseTrait.php
@@ -19,7 +19,7 @@ use WP_Error;
 trait TestCaseTrait {
 
 	/**
-	 * An instanciated `__return_true()`.
+	 * An instantiated `__return_true()`.
 	 *
 	 * @return bool
 	 */
@@ -28,7 +28,7 @@ trait TestCaseTrait {
 	}
 
 	/**
-	 * An instanciated `__return_false()`.
+	 * An instantiated `__return_false()`.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
See [the php doc](https://www.php.net/manual/en/reflectionproperty.setvalue.php).

Since php 8.3:
>Calling this method with a single argument is deprecated, instead use ReflectionProperty::setValue(null, $value) for static properties.

Also fixes some typos.